### PR TITLE
Fix NSTimer: ScrollView keeps timing

### DIFF
--- a/CarouselDemo/PSCarouselView/PSCarouselView.m
+++ b/CarouselDemo/PSCarouselView/PSCarouselView.m
@@ -295,6 +295,7 @@ UICollectionViewDelegateFlowLayout>
     PSWeaker *weaker = [[PSWeaker alloc] initWithObject:self];
     self.timer = [NSTimer scheduledTimerWithTimeInterval:speed target:weaker selector:@selector(moveToNextPage) userInfo:nil repeats:YES];
     self.timer.tolerance = 0.1 * speed;// for increased power savings and responsiveness
+    [[NSRunLoop currentRunLoop] addTimer:self.timer forMode:NSRunLoopCommonModes];//
 }
 
 - (void)removeTimer


### PR DESCRIPTION
在滑动时轮播停止，切换RunLoop的Mode到NSRunLoopCommonModes会修复这个问题。